### PR TITLE
hotfix: `StakingOutputIdx` is not set in delegation type conversion

### DIFF
--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -247,16 +247,17 @@ func ConvertDelegationType(del *btcstakingtypes.BTCDelegation) *types.Delegation
 	}
 
 	return &types.Delegation{
-		BtcPk:           del.BtcPk.MustToBTCPK(),
-		FpBtcPks:        fpBtcPks,
-		TotalSat:        del.TotalSat,
-		StartHeight:     del.StartHeight,
-		EndHeight:       del.EndHeight,
-		StakingTxHex:    stakingTxHex,
-		SlashingTxHex:   slashingTxHex,
-		CovenantSigs:    covenantSigs,
-		UnbondingTime:   del.UnbondingTime,
-		BtcUndelegation: undelegation,
+		BtcPk:            del.BtcPk.MustToBTCPK(),
+		FpBtcPks:         fpBtcPks,
+		TotalSat:         del.TotalSat,
+		StartHeight:      del.StartHeight,
+		EndHeight:        del.EndHeight,
+		StakingTxHex:     stakingTxHex,
+		SlashingTxHex:    slashingTxHex,
+		StakingOutputIdx: del.StakingOutputIdx,
+		CovenantSigs:     covenantSigs,
+		UnbondingTime:    del.UnbondingTime,
+		BtcUndelegation:  undelegation,
 	}
 }
 

--- a/covenant/covenant.go
+++ b/covenant/covenant.go
@@ -3,10 +3,11 @@ package covenant
 import (
 	"bytes"
 	"fmt"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -169,6 +170,13 @@ func (ce *CovenantEmulator) AddCovenantSignatures(btcDels []*types.Delegation) (
 			uint16(unbondingTime),
 			&ce.config.BTCNetParams,
 		); err != nil {
+			ce.logger.Error("invalid delegation",
+				zap.String("staker_pk", bbntypes.NewBIP340PubKeyFromBTCPK(btcDel.BtcPk).MarshalHex()),
+				zap.String("finality_provider_pk", bbntypes.NewBIP340PubKeyFromBTCPK(btcDel.FpBtcPks[0]).MarshalHex()),
+				zap.String("staking_tx_hex", btcDel.StakingTxHex),
+				zap.String("slashing_tx_hex", btcDel.SlashingTxHex),
+				zap.Error(err),
+			)
 			return nil, fmt.Errorf("invalid txs in the delegation: %w", err)
 		}
 

--- a/covenant/covenant_test.go
+++ b/covenant/covenant_test.go
@@ -83,6 +83,8 @@ func FuzzAddCovenantSig(f *testing.F) {
 			stakingTxBytes, err := bbntypes.SerializeBTCTx(testInfo.StakingTx)
 			require.NoError(t, err)
 			startHeight := datagen.RandomInt(r, 1000) + 100
+			stakingOutputIdx, err := bbntypes.GetOutputIdxInBTCTx(testInfo.StakingTx, testInfo.StakingInfo.StakingOutput)
+			require.NoError(t, err)
 			btcDel := &types.Delegation{
 				BtcPk:            delPK,
 				FpBtcPks:         fpPks,
@@ -91,7 +93,7 @@ func FuzzAddCovenantSig(f *testing.F) {
 				TotalSat:         uint64(stakingValue),
 				UnbondingTime:    uint32(unbondingTime),
 				StakingTxHex:     hex.EncodeToString(stakingTxBytes),
-				StakingOutputIdx: 0,
+				StakingOutputIdx: stakingOutputIdx,
 				SlashingTxHex:    testInfo.SlashingTx.ToHexStr(),
 			}
 			btcDels = append(btcDels, btcDel)

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -24,6 +24,7 @@ import (
 	covcc "github.com/babylonchain/covenant-emulator/clientcontroller"
 	covcfg "github.com/babylonchain/covenant-emulator/config"
 	"github.com/babylonchain/covenant-emulator/covenant"
+	"github.com/babylonchain/covenant-emulator/testutil"
 	"github.com/babylonchain/covenant-emulator/types"
 )
 
@@ -238,7 +239,7 @@ func (tm *TestManager) InsertBTCDelegation(t *testing.T, fpPks []*btcec.PublicKe
 	require.NoError(t, err)
 
 	unbondingTime := uint16(tm.StakingParams.MinimumUnbondingTime()) + 1
-	testStakingInfo := datagen.GenBTCStakingSlashingInfo(
+	testStakingInfo := testutil.GenBTCStakingSlashingInfo(
 		r,
 		t,
 		btcNetworkParams,
@@ -293,7 +294,7 @@ func (tm *TestManager) InsertBTCDelegation(t *testing.T, fpPks []*btcec.PublicKe
 	// delegator sig
 	delegatorSig, err := testStakingInfo.SlashingTx.Sign(
 		testStakingInfo.StakingTx,
-		0,
+		1,
 		slashignSpendInfo.GetPkScriptPath(),
 		delBtcPrivKey,
 	)
@@ -310,7 +311,7 @@ func (tm *TestManager) InsertBTCDelegation(t *testing.T, fpPks []*btcec.PublicKe
 		fpPks,
 		params.CovenantPks,
 		params.CovenantQuorum,
-		wire.NewOutPoint(&stakingTxHash, 0),
+		wire.NewOutPoint(&stakingTxHash, 1),
 		unbondingTime,
 		unbondingValue,
 		params.SlashingAddress.String(),

--- a/testutil/datagen.go
+++ b/testutil/datagen.go
@@ -7,13 +7,30 @@ import (
 	"time"
 
 	sdkmath "cosmossdk.io/math"
+	"github.com/babylonchain/babylon/btcstaking"
 	"github.com/babylonchain/babylon/testutil/datagen"
+	bstypes "github.com/babylonchain/babylon/x/btcstaking/types"
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 
 	"github.com/babylonchain/covenant-emulator/types"
 )
+
+type TestStakingSlashingInfo struct {
+	StakingTx   *wire.MsgTx
+	SlashingTx  *bstypes.BTCSlashingTx
+	StakingInfo *btcstaking.StakingInfo
+}
+
+type spendableOut struct {
+	prevOut wire.OutPoint
+	amount  btcutil.Amount
+}
 
 func GenRandomHexStr(r *rand.Rand, length uint64) string {
 	randBytes := datagen.GenRandomByteArray(r, length)
@@ -66,4 +83,125 @@ func GenBtcPublicKeys(r *rand.Rand, t *testing.T, num int) []*btcec.PublicKey {
 	}
 
 	return pks
+}
+
+func GenBTCStakingSlashingInfo(
+	r *rand.Rand,
+	t testing.TB,
+	btcNet *chaincfg.Params,
+	stakerSK *btcec.PrivateKey,
+	fpPKs []*btcec.PublicKey,
+	covenantPKs []*btcec.PublicKey,
+	covenantQuorum uint32,
+	stakingTimeBlocks uint16,
+	stakingValue int64,
+	slashingAddress string,
+	slashingRate sdkmath.LegacyDec,
+	slashingChangeLockTime uint16,
+) *TestStakingSlashingInfo {
+	// an arbitrary input
+	unbondingTxFee := r.Int63n(1000) + 1
+	spend := makeSpendableOutWithRandOutPoint(r, btcutil.Amount(stakingValue+unbondingTxFee))
+	outPoint := &spend.prevOut
+	return GenBTCStakingSlashingInfoWithOutPoint(
+		r,
+		t,
+		btcNet,
+		outPoint,
+		stakerSK,
+		fpPKs,
+		covenantPKs,
+		covenantQuorum,
+		stakingTimeBlocks,
+		stakingValue,
+		slashingAddress,
+		slashingRate,
+		slashingChangeLockTime,
+	)
+}
+
+func makeSpendableOutWithRandOutPoint(r *rand.Rand, amount btcutil.Amount) spendableOut {
+	out := randOutPoint(r)
+
+	return spendableOut{
+		prevOut: out,
+		amount:  amount,
+	}
+}
+
+func GenBTCStakingSlashingInfoWithOutPoint(
+	r *rand.Rand,
+	t testing.TB,
+	btcNet *chaincfg.Params,
+	outPoint *wire.OutPoint,
+	stakerSK *btcec.PrivateKey,
+	fpPKs []*btcec.PublicKey,
+	covenantPKs []*btcec.PublicKey,
+	covenantQuorum uint32,
+	stakingTimeBlocks uint16,
+	stakingValue int64,
+	slashingAddress string,
+	slashingRate sdkmath.LegacyDec,
+	slashingChangeLockTime uint16,
+) *TestStakingSlashingInfo {
+
+	stakingInfo, err := btcstaking.BuildStakingInfo(
+		stakerSK.PubKey(),
+		fpPKs,
+		covenantPKs,
+		covenantQuorum,
+		stakingTimeBlocks,
+		btcutil.Amount(stakingValue),
+		btcNet,
+	)
+
+	require.NoError(t, err)
+	tx := wire.NewMsgTx(2)
+
+	// 2 outputs for changes and staking output
+	changeAddrScript, err := datagen.GenRandomPubKeyHashScript(r, btcNet)
+	require.NoError(t, err)
+	require.False(t, txscript.GetScriptClass(changeAddrScript) == txscript.NonStandardTy)
+
+	tx.AddTxOut(wire.NewTxOut(10000, changeAddrScript)) // output for change
+
+	// add the given tx input
+	txIn := wire.NewTxIn(outPoint, nil, nil)
+	tx.AddTxIn(txIn)
+	tx.AddTxOut(stakingInfo.StakingOutput)
+
+	// construct slashing tx
+	slashingAddrBtc, err := btcutil.DecodeAddress(slashingAddress, btcNet)
+	require.NoError(t, err)
+
+	slashingMsgTx, err := btcstaking.BuildSlashingTxFromStakingTxStrict(
+		tx,
+		uint32(1),
+		slashingAddrBtc,
+		stakerSK.PubKey(),
+		slashingChangeLockTime,
+		2000,
+		slashingRate,
+		btcNet)
+	require.NoError(t, err)
+	slashingTx, err := bstypes.NewBTCSlashingTxFromMsgTx(slashingMsgTx)
+	require.NoError(t, err)
+
+	return &TestStakingSlashingInfo{
+		StakingTx:   tx,
+		SlashingTx:  slashingTx,
+		StakingInfo: stakingInfo,
+	}
+}
+
+func randOutPoint(r *rand.Rand) wire.OutPoint {
+	hash, _ := chainhash.NewHash(datagen.GenRandomByteArray(r, chainhash.HashSize))
+	// TODO this will be deterministic without seed but for now it is not that
+	// important
+	idx := r.Uint32()
+
+	return wire.OutPoint{
+		Hash:  *hash,
+		Index: idx,
+	}
 }


### PR DESCRIPTION
This pr fixed #30 which is caused by `StakingOutputIdx` not being set in the delegation type conversion (thus value being `0` by default).

The error is reproduced in [a2f3e52](https://github.com/babylonchain/covenant-emulator/commit/a2f3e52019647d7414131ebf99d3cbce4e371c37) by constructing staking output in index `1` other than `0`. Testing utilities are adapted from [babylon](https://github.com/babylonchain/babylon/blob/e4dabb05c03f5370607ed51c3aa80e60184f50f4/testutil/datagen/btcstaking.go#L319) with staking output set in index `1` other than `0`.

Bug fix is in [7c86e5a](https://github.com/babylonchain/covenant-emulator/commit/7c86e5a51b9ebd7dadc636d3f962b4eb9dbec555).