### PR TITLE
chore: Use correct minUnbondingTime from params

### DIFF
--- a/covenant/covenant.go
+++ b/covenant/covenant.go
@@ -148,10 +148,10 @@ func (ce *CovenantEmulator) AddCovenantSignatures(btcDels []*types.Delegation) (
 		// - MinUnbondingTime
 		// - CheckpointFinalizationTimeout
 		unbondingTime := btcDel.UnbondingTime
-		minUnbondingTime := params.MinUnbondingTime
-		if unbondingTime <= minUnbondingTime {
+		minUnbondingTime := params.MinimumUnbondingTime()
+		if uint64(unbondingTime) <= minUnbondingTime {
 			ce.logger.Error("invalid unbonding time",
-				zap.Uint32("min_unbonding_time", minUnbondingTime),
+				zap.Uint64("min_unbonding_time", minUnbondingTime),
 				zap.Uint32("got_unbonding_time", unbondingTime),
 			)
 			continue


### PR DESCRIPTION
`minUnbondingTime` should be obtained from `max(MinUnbondingTime, CheckpointFinalizationTimeout)` to be consistent with the check in [CreateBTCDelegation](https://github.com/babylonchain/babylon/blob/013f733e95376b32b9cd82bac42d79fee8f21196/x/btcstaking/keeper/msg_server.go#L167)